### PR TITLE
pmatch: on seeing a special symbol, mark the offset in the input string

### DIFF
--- a/libhfst/src/implementations/optimized-lookup/pmatch.cc
+++ b/libhfst/src/implementations/optimized-lookup/pmatch.cc
@@ -14,7 +14,7 @@ namespace hfst_ol {
 PmatchAlphabet::PmatchAlphabet(std::istream & inputstream,
                                SymbolNumber symbol_count):
     TransducerAlphabet(inputstream, symbol_count, false),
-    special_symbols(12, NO_SYMBOL_NUMBER) // SpecialSymbols enum
+    special_symbols(SPECIALSYMBOL_NR_ITEMS, NO_SYMBOL_NUMBER) // SpecialSymbols enum
 {
     symbol2lists = SymbolNumberVector(orig_symbol_count, NO_SYMBOL_NUMBER);
     list2symbols = SymbolNumberVector(orig_symbol_count, NO_SYMBOL_NUMBER);
@@ -88,6 +88,8 @@ void PmatchAlphabet::add_special_symbol(const std::string & str,
         special_symbols[NRC_exit] = symbol_number;
     } else if (str == "@PMATCH_PASSTHROUGH@") {
         special_symbols[Pmatch_passthrough] = symbol_number;
+    } else if (str == "@PMATCH_INPUT_MARK@") {
+        special_symbols[Pmatch_input_mark] = symbol_number;
     } else if (str == "@BOUNDARY@") {
         special_symbols[boundary] = symbol_number;
     } else if (is_end_tag(str)) {
@@ -385,8 +387,7 @@ bool PmatchAlphabet::is_counter(const SymbolNumber symbol) const
 
 bool PmatchAlphabet::is_input_mark(const SymbolNumber symbol) const
 {
-    // TODO: Special tag in symbol table or such; not printable
-    return string_from_symbol(symbol) == "¤";
+    return get_special(Pmatch_input_mark) == symbol;
 }
 
 std::string PmatchAlphabet::name_from_insertion(const std::string & symbol)
@@ -737,7 +738,8 @@ Location PmatchAlphabet::locatefy(unsigned int input_offset,
     Location retval;
     retval.start = input_offset;
     retval.weight = str.weight;
-    size_t part_offset = 0;
+    size_t input_mark = 0;
+    size_t output_mark = 0;
 
     // We rebuild the original input without special
     // symbols but with IDENTITIES etc. replaced
@@ -757,12 +759,17 @@ Location PmatchAlphabet::locatefy(unsigned int input_offset,
             ++input_offset;
         }
         if (is_input_mark(output)) {
-            retval.input_parts.push_back(retval.input.substr(part_offset));
-            part_offset = retval.input.size();
+            retval.output_parts.push_back(output_mark);
+            retval.input_parts.push_back(input_mark);
+            output_mark = retval.output.size();
+            input_mark = retval.input.size();
         }
     }
-    if (part_offset > 0) {
-        retval.input_parts.push_back(retval.input.substr(part_offset));
+    if (output_mark > 0) {
+        retval.output_parts.push_back(output_mark);
+    }
+    if (input_mark > 0) {
+        retval.input_parts.push_back(input_mark);
     }
     retval.length = input_offset - retval.start;
     return retval;

--- a/libhfst/src/implementations/optimized-lookup/pmatch.h
+++ b/libhfst/src/implementations/optimized-lookup/pmatch.h
@@ -114,6 +114,7 @@ namespace hfst_ol {
         SymbolNumberVector guards;
         std::vector<bool> printable_vector;
         bool is_end_tag(const SymbolNumber symbol) const;
+        bool is_input_mark(const SymbolNumber symbol) const;
         bool is_guard(const SymbolNumber symbol) const;
         bool is_counter(const SymbolNumber symbol) const;
         std::string end_tag(const SymbolNumber symbol);
@@ -243,6 +244,7 @@ namespace hfst_ol {
         std::string output;
         std::string tag;
         Weight weight;
+        std::vector<std::string> input_parts;
 
         bool operator<(Location rhs) const
             { return this->weight < rhs.weight; }

--- a/libhfst/src/implementations/optimized-lookup/pmatch.h
+++ b/libhfst/src/implementations/optimized-lookup/pmatch.h
@@ -43,7 +43,9 @@ namespace hfst_ol {
                        NRC_entry,
                        NRC_exit,
                        Pmatch_passthrough,
-                       boundary};
+                       boundary,
+                       Pmatch_input_mark,
+                       SPECIALSYMBOL_NR_ITEMS};
 
     struct SymbolPair
     {
@@ -244,7 +246,8 @@ namespace hfst_ol {
         std::string output;
         std::string tag;
         Weight weight;
-        std::vector<std::string> input_parts;
+        std::vector<size_t> input_parts;
+        std::vector<size_t> output_parts;
 
         bool operator<(Location rhs) const
             { return this->weight < rhs.weight; }


### PR DESCRIPTION
This patch gives pmatch a new special symbol `@PMATCH_INPUT_MARK@`. This tells pmatch to  note the string offsets of the matched input/output strings seen until now. 

This is not the offset in the stream, but within the match. It's also a string offset, not symbol offset, since the user (e.g. hfst-tokenise) doesn't access the symbol vectors, but the strings.


The use-case is handling ambiguous multiword units that should be split after a disambiguation step. An example is:

    leaba    leat+V+Du
    leaba    leat+V+Sg@PMATCH_INPUT_MARK@ba+Pcle

If the second reading is chosen after analysis and disambiguation, then we want to split it into 

    lea    leat+V+Sg
    
    ba    ba+Pcle

but we need to know where to split the *form* (not just the analysis). Similarly for things like "3." which might be `3.Adj+Ord` or `3+Num@PMATCH_INPUT_MARK@.+PUNCT`, or space/dash-separated multiwords that are ambiguous with consecutive single words. For any single such example, we could invent a hack to find the split-point, but we would like a general and language-agnostic method.


