### PR TITLE
Escape " in dot labels

### DIFF
--- a/libhfst/src/HfstPrintDot.cc
+++ b/libhfst/src/HfstPrintDot.cc
@@ -196,7 +196,9 @@ print_dot(FILE* out, HfstTransducer& t)
                       } // if old label empty
                   } // if weighted
               } // if id pair
-            target_labels[arc->get_target_state()] = l;
+            string sl(l);
+            replace_all(sl, "\"", "\\\"");
+            target_labels[arc->get_target_state()] = sl;
             free(l);
           } // each arc
         for (std::map<HfstState,std::string>::const_iterator tl = target_labels.begin();
@@ -392,7 +394,9 @@ print_dot(std::ostream & out, HfstTransducer& t)
                       } // if old label empty
                   } // if weighted
               } // if id pair
-            target_labels[arc->get_target_state()] = l;
+            string sl(l);
+            replace_all(sl, "\"", "\\\"");
+            target_labels[arc->get_target_state()] = sl;
             free(l);
           } // each arc
         for (std::map<HfstState,std::string>::const_iterator tl = target_labels.begin();

--- a/libhfst/src/Makefile.am
+++ b/libhfst/src/Makefile.am
@@ -24,7 +24,8 @@ HFST_SRCS=HfstApply.cc HfstInputStream.cc HfstTransducer.cc HfstOutputStream.cc\
 		  HarmonizeUnknownAndIdentitySymbols.cc \
 		  HfstLookupFlagDiacritics.cc \
 		  HfstEpsilonHandler.cc HfstStrings2FstTokenizer.cc \
-		  HfstPrintDot.cc HfstPrintPCKimmo.cc hfst-string-conversions.cc
+		  HfstPrintDot.cc HfstPrintPCKimmo.cc hfst-string-conversions.cc \
+		  string-utils.cc
 
 # libtool takes over
 libhfst_la_SOURCES = $(HFST_SRCS)
@@ -93,6 +94,7 @@ HFST_HDRS = \
 	HfstStrings2FstTokenizer.h \
 	HfstPrintDot.h \
 	HfstPrintPCKimmo.h \
+	string-utils.h \
 	hfst-string-conversions.h \
 	parsers/LexcCompiler.h parsers/XreCompiler.h parsers/PmatchCompiler.h \
 	hfstdll.h

--- a/libhfst/src/implementations/HfstTransitionGraph.h
+++ b/libhfst/src/implementations/HfstTransitionGraph.h
@@ -31,6 +31,7 @@
  #include "HfstTransition.h"
  #include "HfstTropicalTransducerTransitionData.h"
 //#include "HfstFastTransitionData.h"
+ #include "../string-utils.h"
 
  #include "../hfstdll.h"
 
@@ -788,22 +789,6 @@
            //  os << 0; 
            //else
            os << weight;
-         }
-
-         /* Replace all strings \a str1 in \a symbol with \a str2. */
-         static void replace_all(std::string & symbol, 
-                                 const std::string &str1,
-                                 const std::string &str2)
-         {
-           size_t pos = symbol.find(str1);
-           while (pos != std::string::npos) // while there are str1:s to replace
-             {
-               symbol.erase(pos, str1.size()); // erase str1
-               symbol.insert(pos, str2);       // insert str2 instead
-               pos = symbol.find               // find next str1
-                 (str1, pos+str2.size());      
-             }
-           return;
          }
 
          static void xfstize(std::string & symbol)

--- a/libhfst/src/parsers/lexc-utils.cc
+++ b/libhfst/src/parsers/lexc-utils.cc
@@ -29,6 +29,7 @@
 
 #include "LexcCompiler.h"
 #include "lexc-utils.h"
+#include "string-utils.h"
 
 #ifdef YACC_USE_PARSER_H_EXTENSION
   #include "lexc-parser.h"
@@ -47,21 +48,6 @@ extern YYLTYPE hlexclloc;
 namespace hfst { namespace lexc {
 
 extern hfst::lexc::LexcCompiler * lexc_;
-
-// string mangling
-static
-string&
-replace_all(string& haystack, const string& needle, const string& replacement)
-  {
-    size_t last_needle = haystack.find(needle);
-    size_t needle_len = needle.length();
-    while (last_needle != string::npos)
-      {
-        haystack.replace(last_needle, needle_len, replacement);
-        last_needle = haystack.find(needle);
-      }
-    return haystack;
-  }
 
 
 string&

--- a/libhfst/src/string-utils.cc
+++ b/libhfst/src/string-utils.cc
@@ -1,0 +1,34 @@
+// Copyright (c) 2016 University of Helsinki
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+// See the file COPYING included with this distribution for more
+// information.
+
+//! @file string-utils.cc
+//!
+//! @brief Implementation of some string manipulation utilities.
+
+#include "string-utils.h"
+
+using std::string;
+
+namespace hfst {
+
+string&
+replace_all(string& haystack, const string& needle, const string& replacement)
+  {
+    size_t last_needle = haystack.find(needle);
+    size_t needle_len = needle.length();
+    size_t replacement_len = replacement.length();
+    while (last_needle != string::npos)
+      {
+        haystack.replace(last_needle, needle_len, replacement);
+        last_needle = haystack.find(needle, last_needle + replacement_len);
+      }
+    return haystack;
+  }
+
+}

--- a/libhfst/src/string-utils.h
+++ b/libhfst/src/string-utils.h
@@ -1,0 +1,31 @@
+// Copyright (c) 2016 University of Helsinki
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+// See the file COPYING included with this distribution for more
+// information.
+
+//! @file string-utils.h
+//!
+//! @brief String manipulation utilities.
+
+#ifndef GUARD_string_utils_h
+#define GUARD_string_utils_h
+
+#include <string>
+
+using std::string;
+
+namespace hfst {
+
+//! @brief Replace all strings needles in haystack with replacement, moving
+//! the cursor past the replacement each time, ie if needle is in replacement,
+//! it won't be replaced. */
+
+string& replace_all(string& haystack, const string& needle, const string& replacement);
+
+}
+
+#endif // GUARD_string_utils_h


### PR DESCRIPTION
This also fixes addPercents which with the previous replace_all wouldn't terminate. It seems as though it's not actually in use. Perhaps it should be removed?