### PR TITLE
Ensure print_dot labels are valid utf-8

### DIFF
--- a/libhfst/src/HfstPrintDot.cc
+++ b/libhfst/src/HfstPrintDot.cc
@@ -51,6 +51,30 @@ namespace hfst {
 #endif
 
 void
+trim_to_valid_utf8(char* inp)
+  {
+    size_t len = strlen(inp);
+    for (int i=1;i<4&&(len-i>0);i++)
+      {
+        if (i < 2 && ((inp[len-i] & 0xc0) == 0xc0))
+          {
+            inp[len-i] = '\0';
+            return;
+          }
+        else if (i < 3 && ((inp[len-i] & 0xe0) == 0xe0))
+          {
+            inp[len-i] = '\0';
+            return;
+          }
+        else if (i < 4 && ((inp[len-i] & 0xf0) == 0xf0))
+          {
+            inp[len-i] = '\0';
+            return;
+          }
+      }
+  }
+
+void
 print_dot(FILE* out, HfstTransducer& t)
   {
     //fprintf(out, "// This graph generated with hfst-fst2txt\n");
@@ -232,6 +256,7 @@ print_dot(FILE* out, HfstTransducer& t)
                       } // if old label empty
                   } // if weighted
               } // if id pair
+            trim_to_valid_utf8(l);
             string sl(l);
             replace_all(sl, "\"", "\\\"");
             target_labels[arc->get_target_state()] = sl;
@@ -430,6 +455,7 @@ print_dot(std::ostream & out, HfstTransducer& t)
                       } // if old label empty
                   } // if weighted
               } // if id pair
+            trim_to_valid_utf8(l);
             string sl(l);
             replace_all(sl, "\"", "\\\"");
             target_labels[arc->get_target_state()] = sl;


### PR DESCRIPTION
Currently print_dot truncates long labels to a fixed number of octets,
but this can cause the label to terminate with an incomplete codepoint
sequence, resulting in errors when attempting to use the output with
tools such as xdot.

Like last time I modified this function, there's two copies! One for file pointers and one for ostreams. It seems a bit messy (not DRY) to me. Are they actually both needed. I think I see why it might've come about that there are two (it's tricky to get one from another e.g. pulling in Boost, see https://stackoverflow.com/questions/2746168/how-to-construct-a-c-fstream-from-a-posix-file-descriptor ) but if it's easy to get rid of one that might be better.