### PR TITLE
pamtch: Make INPUT_MARK not special_symbols, so we can refer to it in pmscripts

### DIFF
--- a/libhfst/src/implementations/optimized-lookup/pmatch.cc
+++ b/libhfst/src/implementations/optimized-lookup/pmatch.cc
@@ -32,7 +32,10 @@ PmatchAlphabet::PmatchAlphabet(std::istream & inputstream,
         if (is_special(symbol_table[i])) {
             add_special_symbol(symbol_table[i], i);
         } else {
-            if (!is_flag_diacritic(i)) {
+            if(symbol_table[i]=="@PMATCH_INPUT_MARK@") {
+                input_mark_symbol = i;
+            }
+            else if (!is_flag_diacritic(i)) {
                 printable_vector[i] = true;
             } else {
                 if (is_global_flag(symbol_table[i])) {
@@ -140,8 +143,6 @@ void PmatchAlphabet::add_special_symbol(const std::string & str,
         special_symbols[NRC_exit] = symbol_number;
     } else if (str == "@PMATCH_PASSTHROUGH@") {
         special_symbols[Pmatch_passthrough] = symbol_number;
-    } else if (str == "@PMATCH_INPUT_MARK@") {
-        special_symbols[Pmatch_input_mark] = symbol_number;
     } else if (str == "@BOUNDARY@") {
         special_symbols[boundary] = symbol_number;
     } else if (is_end_tag(str)) {
@@ -668,6 +669,9 @@ bool PmatchAlphabet::is_special(const std::string & symbol)
     if (symbol.size() < 3) {
         return false;
     }
+    if (symbol == "@PMATCH_INPUT_MARK@") { // seems like is_special symbols can't be referred to in pmatch scripts
+        return false;
+    }
     if (is_insertion(symbol) || symbol == "@BOUNDARY@") {
 //        || symbol == "@_UNKNOWN_SYMBOL_@" || symbol == "@_IDENTITY_SYMBOL_@"
         return true;
@@ -703,7 +707,7 @@ bool PmatchAlphabet::is_counter(const SymbolNumber symbol) const
 
 bool PmatchAlphabet::is_input_mark(const SymbolNumber symbol) const
 {
-    return get_special(Pmatch_input_mark) == symbol;
+    return input_mark_symbol == symbol;
 }
 
 std::string PmatchAlphabet::name_from_insertion(const std::string & symbol)

--- a/libhfst/src/implementations/optimized-lookup/pmatch.h
+++ b/libhfst/src/implementations/optimized-lookup/pmatch.h
@@ -63,6 +63,7 @@ namespace hfst_ol {
     class PmatchAlphabet: public TransducerAlphabet {
     protected:
         RtnVector rtns;
+        SymbolNumber input_mark_symbol;
         SymbolNumberVector special_symbols;
         std::map<SymbolNumber, std::string> end_tag_map;
         std::map<std::string, SymbolNumber> capture_tag_map;


### PR DESCRIPTION
There's a test in `PmatchAlphabet::is_special` 

        return (symbol.find("@PMATCH") == 0 && symbol.at(symbol.size() - 1) == '@')

which makes tags like `@PMATCH_INPUT_MARK@` special, and it seems any "special" symbol can not be referred to as tags in pmatch scripts. However `@PMATCH_INPUT_MARK@` is not special in the same sense as `@PMATCH_ENTRY@` or `@PMATCH_LC_EXIT@` since it occurs in the actual morphologies we include with `@bin"analyser.hfst"`. 

That is, if we do

```
Define morphology @bin"analyser.hfst" ;  !! contains 1:1 0: Tag 0:@PMATCH_INPUT_MARK@ .:. 0:Tag2
Define inputmark    [ 0:"@PMATCH_INPUT_MARK@" ];
Define any [ ? | 0:? | inputmark | flags ];
Define dotinside      morphology & [ any* {.} any* ] ;
```
then `dotinside` won't match the analysis (or even if we call it `@PMATCH_JUST_MADE_THIS_UP@` in the hfst and pmscript).


This change makes `@PMATCH_INPUT_MARK@` no longer "special", instead just storing the symbol in `PmatchAlphabet.input_mark_symbol`, letting us match on it in pmscripts.

-----

However, it's sort of an XY problem – I'd prefer to have a way to skip any "invisible" tag sequence (including "PMATCH_INPUT_MARK" or flag diacritics) when intersecting the morphology with a pmatch expression, ie. I'd like to be able to match anything from the morphology that ends in punctuation, regardless of whether it has flags and input-marks after the punctuation and allowing *anything* before the punctuation:

```
Define endsInPunct      morphology & [ printableOrUnprintable* Punct unprintable* ] ;
```