### PR TITLE
Use ICU if possible to find characterBoundary in is_cg_tag

### DIFF
--- a/libhfst/src/implementations/Makefile.am
+++ b/libhfst/src/implementations/Makefile.am
@@ -28,7 +28,7 @@ IMPLEMENTATION_SRCS=ConvertTransducerFormat.cc \
 AM_CXXFLAGS=-Wno-deprecated -g
 
 AM_CPPFLAGS = -I${top_srcdir}/libhfst/src -I${top_srcdir}/back-ends/foma \
-		-I${top_srcdir}/back-ends
+		-I${top_srcdir}/back-ends ${ICU_CPPFLAGS}
 
 if WANT_MINGW
   AM_CPPFLAGS += -I${top_srcdir}/back-ends/openfstwin/src/include \


### PR DESCRIPTION
If we have a non-composed character on a single arc, e.g.

    0	1	ǩ	ǩ	0.000000

(where the ǩ consists of two codepoints "k" and "̌")

and run "hfst-tokenize -g -m", the lemma would get misprinted since we
considered >1 codepoint on one arc to be a tag. But in this case, the
two codepoints correspond to one character – if we have ICU, we can
find that out with a Character BreakIterator.

So with ICU, tags are defined as having at least one byte after the
first character as returned by a Character BreakIterator.

Should fix #440 - Lemma misprinted in hfst-tokenise -g when using -m