### PR TITLE
Fst2txt union

### DIFF
--- a/man/hfst-txt2fst.1
+++ b/man/hfst-txt2fst.1
@@ -40,6 +40,9 @@ Interpret string EPS as epsilon in att format
 .TP
 \fB\-p\fR, \fB\-\-prolog\fR
 Read prolog format instead of att
+.TP
+\fB\-j\fR, \fB\-\-disjunct\fR
+Disjunct multiple transducers in input
 .SS "Other options:"
 .TP
 \fB\-C\fR, \fB\-\-check\-negative\-epsilon\-cycles\fR


### PR DESCRIPTION
This adds an option `-j` to `hfst-txt2fst to allow it to union multiple transducers in input. This will close #474.