### PR TITLE
Parse wordbound blanks as normal blanks in hfst-proc

### DIFF
--- a/tools/src/hfst-proc/tokenizer.cc
+++ b/tools/src/hfst-proc/tokenizer.cc
@@ -188,20 +188,20 @@ TokenIOStream::read_delimited(const char delim)
   int c = EOF;
   bool is_wblank = false;
   
-  if(is && c != delim) //Check if wblank is being read
+  if(is && c != delim)
   {
     c = is.get();
-    if(c == '[')
+    if(c != EOF)
     {
       result += c;
       if(c == '\\')
         result += read_escaped();
       else if(null_flush && c == '\0')
         do_null_flush();
-      else
+      else if(c == '[')
       {
         int next_char = is.peek();
-        if(next_char == '[')
+        if(next_char == '[') //Check if wblank is being read
           is_wblank = true;
       }
     }

--- a/tools/src/hfst-proc/tokenizer.cc
+++ b/tools/src/hfst-proc/tokenizer.cc
@@ -184,7 +184,6 @@ TokenIOStream::read_escaped()
 std::string
 TokenIOStream::read_delimited(const char delim)
 {
-  wcerr << "\n\n##TEST##\n\n";
   std::string result;
   int c = EOF;
   bool is_wblank = false;
@@ -192,19 +191,19 @@ TokenIOStream::read_delimited(const char delim)
   if(is && c != delim) //Check if wblank is being read
   {
     c = is.get();
-    if(c == EOF || c != '[')
-      break;
-    
-    result += c;
-    if(c == '\\')
-      result += read_escaped();
-    else if(null_flush && c == '\0')
-      do_null_flush();
-    else
+    if(c == '[')
     {
-      int next_char = is.peek();
-      if(next_char == '[')
-        is_wblank = true;
+      result += c;
+      if(c == '\\')
+        result += read_escaped();
+      else if(null_flush && c == '\0')
+        do_null_flush();
+      else
+      {
+        int next_char = is.peek();
+        if(next_char == '[')
+          is_wblank = true;
+      }
     }
   }
   
@@ -224,16 +223,16 @@ TokenIOStream::read_delimited(const char delim)
   if(is_wblank)
   {
     c = is.get();
-    if(c == EOF)
-      break;
-    
-    if(c != delim)
+    if(c != EOF)
     {
-      stream_error(std::string("Error in parsing a wordbound blank"));
-    }
-    else
-    {
-      result += c;
+      if(c != delim)
+      {
+        stream_error(std::string("Error in parsing a wordbound blank"));
+      }
+      else
+      {
+        result += c;
+      }
     }
   }
 

--- a/tools/src/hfst-proc/tokenizer.h
+++ b/tools/src/hfst-proc/tokenizer.h
@@ -187,6 +187,7 @@ class TokenIOStream
    * Read into the the stream until the delimiting character is found. The
    * delimiting character is read and included in the string. Charater escaping
    * is handled. Fails on stream error
+   * If a wblank is being parsed, then the parsing happens till ]] is reached.
    * @return the string from the stream's current point up to and including
    *         the delimiting character
    */


### PR DESCRIPTION
Changes made to the tokeniser in hfst-proc, such that wordbound blanks are parsed as normal blanks.