### PR TITLE
Allow hfst-xfst to source from absolute paths

### DIFF
--- a/libhfst/src/parsers/xfst-lexer.ll
+++ b/libhfst/src/parsers/xfst-lexer.ll
@@ -742,7 +742,7 @@ LWSP [\t ]*
     return REGEX;
 }
 
-<SOURCE_STATE>[A-Za-z]{NAMECHAR}* {
+<SOURCE_STATE>[A-Za-z\/]{NAMECHAR}* {
   // ^ include directive
 
   FILE * tmp = NULL;


### PR DESCRIPTION
Before:

    $ hfst-xfst
    hfst[0]: source /tmp/foo.lexc
    /Error opening file 'tmp/foo.lexc'

After:

    $ ./tools/src/parsers/hfst-xfst
    hfst[0]: source /tmp/foo.lexc
    hfst[0]:
