### PR TITLE
Fix flex version validation.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -633,9 +633,8 @@ AC_PROG_LEX
 AC_PATH_PROG([GETOPT], [getopts], [false])
 
 AM_PATH_PYTHON([3.0],[],[false])
-# if flex 3.X ever comes out, this breaks :)
 LEX_VERSION=`$LEX --version`
-AS_IF([test -z "`echo "$LEX_VERSION" | grep 'flex 2\.[[5-9]]\.[[3-9][4-9]]'`"],
+AS_IF([test "$LEX_VERSION" \< 'flex 2.5.33'],
       [AC_MSG_WARN([Building hfst successfully requires flex newer than 2.5.33 on some platforms. Unless you are building with pre-flex-generated sources, building will probably fail.])])
 
 AC_PROG_INSTALL

--- a/configure.ac
+++ b/configure.ac
@@ -633,9 +633,6 @@ AC_PROG_LEX
 AC_PATH_PROG([GETOPT], [getopts], [false])
 
 AM_PATH_PYTHON([3.0],[],[false])
-LEX_VERSION=`$LEX --version`
-AS_IF([test "$LEX_VERSION" \< 'flex 2.5.33'],
-      [AC_MSG_WARN([Building hfst successfully requires flex newer than 2.5.33 on some platforms. Unless you are building with pre-flex-generated sources, building will probably fail.])])
 
 AC_PROG_INSTALL
 AC_PROG_LN_S


### PR DESCRIPTION
It is needed in order to skip validation warning when flex `2.6.4` is used because it doesn't conform to invalid regexp.