### PR TITLE
Avoid segfault when regexp parsing fails in lexicon.

### DIFF
--- a/libhfst/src/parsers/LexcCompiler.cc
+++ b/libhfst/src/parsers/LexcCompiler.cc
@@ -716,6 +716,14 @@ LexcCompiler::addXreEntry(const string& regexp, const string& continuation,
     //char* xre_encoded = hfst::xre::add_percents(encodedCont.c_str());
 
     HfstTransducer* newPaths = xre_.compile(regexp);
+    if (newPaths == NULL)
+    {
+        std::ostream * err = get_stream(error_);
+        *err << "Unable to parse regular expression" << std::endl;
+        flush(err);
+        parseErrors_ = true;
+        return *this;
+    }
 
     newPaths->optimize();
 


### PR DESCRIPTION
This pull request fixes issue https://github.com/hfst/hfst/issues/506