### PR TITLE
Fix memory leak in are_equivalent method of FomaTransducer.

### DIFF
--- a/back-ends/foma/structures.c
+++ b/back-ends/foma/structures.c
@@ -322,13 +322,15 @@ int fsm_isuniversal(struct fsm *net) {
 }
 
 int fsm_isempty(struct fsm *net) {
-    struct fsm_state *fsm;
-    net = fsm_minimize(net);
-    fsm = net->states;
+    int result;
+    struct fsm *minimal = fsm_minimize(fsm_copy(net));
+    struct fsm_state *fsm = minimal->states;
     if (fsm->target == -1 && fsm->final_state == 0 && (fsm+1)->state_no == -1)
-        return 1;
+        result = 1;
     else
-        return 0;
+        result = 0;
+    fsm_destroy(minimal);
+    return result;
 }
 
 int fsm_issequential(struct fsm *net) {

--- a/libhfst/src/implementations/FomaTransducer.cc
+++ b/libhfst/src/implementations/FomaTransducer.cc
@@ -496,7 +496,7 @@ namespace hfst { namespace implementations {
       fsm_union(fsm_minus(fsm_copy(t1),fsm_copy(t2)),
                 fsm_minus(fsm_copy(t2),fsm_copy(t1)));
     int eq = fsm_isempty(test);
-    //fsm_destroy(test);
+    fsm_destroy(test);
     return (eq == 1);
   }
 


### PR DESCRIPTION
Also cherry-pick memory leak fixes from fsm_isempty method from upstream foma.