### PR TITLE
Fix implicit fall-through in hfst-optimized-lookup

### DIFF
--- a/tools/src/hfst-optimized-lookup.cc
+++ b/tools/src/hfst-optimized-lookup.cc
@@ -182,6 +182,7 @@ int main(int argc, char **argv)
 
         case 'e':
           echoInputsFlag = true;
+          break;
 
         case 'w':
           displayWeightsFlag = true;


### PR DESCRIPTION
I don’t believe it’s intentional that `-e` to echo inputs implies `-w` to
show weights.

This was found when building our [python (and NodeJS soon too!)
hfst-optimized-lookup package][hfstol] on Ubuntu 21.04.

[hfstol]: https://github.com/ualbertaaltlab/hfst-optimized-lookup

    hfst/tools/src$ g++ -W -Wall -Werror hfst-optimized-lookup.cc
    hfst-optimized-lookup.cc: In function ‘int main(int, char**)’:
    hfst-optimized-lookup.cc:184:26: error: this statement may fall through [-Werror=implicit-fallthrough=]
      184 |           echoInputsFlag = true;
          |           ~~~~~~~~~~~~~~~^~~~~~
    hfst-optimized-lookup.cc:186:9: note: here
      186 |         case 'w':
          |         ^~~~
    cc1plus: all warnings being treated as errors
    Returned 1.