### PR TITLE
Fix memory leak in SFST transducer.

### DIFF
--- a/libhfst/src/implementations/SfstTransducer.cc
+++ b/libhfst/src/implementations/SfstTransducer.cc
@@ -775,7 +775,8 @@ namespace hfst { namespace implementations {
       HfstTwoLevelPath epsilon_path(0, empty_spv);
       callback(epsilon_path, true /* final*/);
     }
-
+    if (fd_state_stack != NULL)
+      { delete fd_state_stack; }
   }
 
   /* Get a random path from transducer \a t. */


### PR DESCRIPTION
Release flag diacritics state stack after paths are extracted.