### PR TITLE
Fix memory leak in FST type formatting.

### DIFF
--- a/tools/src/hfst-commandline.cc
+++ b/tools/src/hfst-commandline.cc
@@ -398,33 +398,33 @@ hfst_strformat(hfst::ImplementationType format)
   switch (format)
     {
     case hfst::SFST_TYPE:
-      return strdup("SFST (1.4 compatible)");
+      return "SFST (1.4 compatible)";
       break;
     case hfst::TROPICAL_OPENFST_TYPE:
-      return strdup("OpenFST, std arc, tropical semiring");
+      return "OpenFST, std arc, tropical semiring";
       break;
     case hfst::LOG_OPENFST_TYPE:
-      return strdup("OpenFST, std arc, log semiring");
+      return "OpenFST, std arc, log semiring";
       break;
     case hfst::FOMA_TYPE:
-      return strdup("foma");
+      return "foma";
       break;
     case hfst::XFSM_TYPE:
-      return strdup("xfsm");
+      return "xfsm";
       break;
     case hfst::HFST_OL_TYPE:
-      return strdup("Hfst's lookup optimized, unweighted");
+      return "Hfst's lookup optimized, unweighted";
       break;
     case hfst::HFST_OLW_TYPE:
-      return strdup("Hfst's lookup optimized, weighted");
+      return "Hfst's lookup optimized, weighted";
       break;
     case hfst::HFST2_TYPE:
-      return strdup("Hfst 2 legacy (deprecated)");
+      return "Hfst 2 legacy (deprecated)";
       break;
     case hfst::ERROR_TYPE:
     case hfst::UNSPECIFIED_TYPE:
     default:
-      return strdup("ERROR (not a HFST supported transducer)");
+      return "ERROR (not a HFST supported transducer)";
       exit(1);
     }
 

--- a/tools/src/hfst-flookup.cc
+++ b/tools/src/hfst-flookup.cc
@@ -1638,16 +1638,14 @@ process_stream(HfstInputStream& inputstream, FILE* outstream)
 
     if (!only_optimized_lookup)
       {
-        char* format_string = hfst_strformat(cascade[0].get_type());
         if (!silent) {
           warning(0, 0,
                   "It is not possible to perform fast lookups with %s "
                   "format automata.\n"
                   "Using HFST basic transducer format "
                   "and performing slow lookups",
-                  format_string);
+                  hfst_strformat(cascade[0].get_type()));
         }
-        free(format_string);
       }
     long filesize = -1;
     if (show_progress_bar)

--- a/tools/src/hfst-fst2fst.cc
+++ b/tools/src/hfst-fst2fst.cc
@@ -260,18 +260,16 @@ int main( int argc, char **argv ) {
     }
     verbose_printf("Reading from %s, writing to %s\n",
         inputfilename, outfilename);
-    char* format_description = hfst_strformat(output_type);
     if (hfst_format && (output_type != hfst::XFSM_TYPE))
       {
         verbose_printf("Writing %s format transducers with HFST3 headers\n",
-                       format_description);
+                       hfst_strformat(output_type));
       }
     else
       {
         verbose_printf("Writing %s format transducers without HFST specific"
-                       " headers\n", format_description);
+                       " headers\n", hfst_strformat(output_type));
       }
-    free(format_description);
 
     if (output_type == hfst::XFSM_TYPE)
       {

--- a/tools/src/hfst-lookup.cc
+++ b/tools/src/hfst-lookup.cc
@@ -1844,16 +1844,14 @@ process_stream(HfstInputStream& inputstream, FILE* outstream)
 
     if (!only_optimized_lookup)
       {
-        char* format_string = hfst_strformat(cascade[0].get_type());
         if (!silent) {
           warning(0, 0,
                   "It is not possible to perform fast lookups with %s "
                   "format automata.\n"
                   "Using HFST basic transducer format "
                   "and performing slow lookups",
-                  format_string);
+                  hfst_strformat(cascade[0].get_type()));
         }
-        free(format_string);
       }
     long filesize = -1;
     if (show_progress_bar)


### PR DESCRIPTION
Use static string instead of heap allocation since it is not supposed to be mutated anyways.