### PR TITLE
Read and write header size in big endian format as docs specify

### DIFF
--- a/libhfst/src/HfstOutputStream.cc
+++ b/libhfst/src/HfstOutputStream.cc
@@ -435,10 +435,12 @@ HfstOutputStream::append_implementation_specific_header_data(std::vector<char>&,
         HFST_THROW_MESSAGE(HfstFatalException, "transducer header is too long");
       }
 
-      char first_byte = *((char*)(&header_length));
-      char second_byte = *((char*)(&header_length)+1);
-      write(first_byte);
-      write(second_byte);
+      // write header length as big endian
+      char be_u16[2];
+      be_u16[0] = static_cast<char>(header_length>>8);
+      be_u16[1] = static_cast<char>(header_length>>0);
+      write(be_u16[0]);
+      write(be_u16[1]);
       write('\0');
 
       // write the rest of the header

--- a/libhfst/src/implementations/optimized-lookup/pmatch.cc
+++ b/libhfst/src/implementations/optimized-lookup/pmatch.cc
@@ -789,8 +789,12 @@ std::map<std::string, std::string> PmatchContainer::parse_hfst3_header(std::istr
     }
     if(header_loc == strlen(header1) + 1)
     {
+        // read header length from big endian format
         unsigned short remaining_header_len;
-        f.read((char*) &remaining_header_len, sizeof(remaining_header_len));
+        char remaining_header_len_bytes[sizeof(remaining_header_len)];
+        f.read((char*) &remaining_header_len_bytes, sizeof(remaining_header_len));
+        remaining_header_len = remaining_header_len_bytes[1]<<0 | remaining_header_len_bytes[0]<<8;
+
         if (f.get() != '\0') {
             HFST_THROW(TransducerHeaderException);
         }


### PR DESCRIPTION
On the page https://github.com/hfst/hfst/wiki/TransducerHeader it is stated that the header size in a HFST header should be specified in big endian format, but the implementation writes and reads the size in native endian format.

I noticed it when I tried to use a precompiled pmatch file (on a little endian system) on a big endian system.

The shifts in the proposed fix is applied on the value of header size and not it's representation.