### PR TITLE
build: unconditionally use C++17

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -658,8 +658,7 @@ AC_CHECK_HEADERS([limits.h stdlib.h string.h error.h glob.h locale.h langinfo.h]
 
 AC_LANG_PUSH([C++])
 
-# If we're using upstream OpenFST then use C++17, otherwise limit to C++14
-AM_COND_IF([WANT_OPENFST_UPSTREAM], [my_CXXFLAGS="-std=c++17"], [my_CXXFLAGS="-std=c++14"])
+my_CXXFLAGS="-std=c++17"
 
 # On 32bit x86, we need to use SSE for precise floating point arithmetics in OpenFST
 AX_CHECK_COMPILE_FLAG([-msse], [my_CXXFLAGS="$my_CXXFLAGS -msse"], [])


### PR DESCRIPTION
Bump the lowest C++ standard "offered" by hfst from c++14 to c++17 because ICU, which, unlike openfst, is a hard requirement, requires C++17 starting with ICU 75.